### PR TITLE
fix: Remove hmac-md5-96 authentication from IPSec VPN policy

### DIFF
--- a/ibm/service/power/resource_ibm_pi_ipsec_policy.go
+++ b/ibm/service/power/resource_ibm_pi_ipsec_policy.go
@@ -74,7 +74,7 @@ func ResourceIBMPIIPSecPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "none",
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"hmac-md5-96", "hmac-sha-256-128", "hmac-sha1-96", "none"}),
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{"hmac-sha-256-128", "hmac-sha1-96", "none"}),
 				Description:  "Authentication for the IPSec Policy",
 			},
 

--- a/ibm/service/power/resource_ibm_pi_ipsec_policy_test.go
+++ b/ibm/service/power/resource_ibm_pi_ipsec_policy_test.go
@@ -33,7 +33,7 @@ func TestAccIBMPIIPSecPolicyBasic(t *testing.T) {
 					testAccCheckIBMPIIPSecPolicyExists(policyRes),
 					resource.TestCheckResourceAttr(policyRes, "pi_policy_name", name),
 					resource.TestCheckResourceAttrSet(policyRes, "policy_id"),
-					resource.TestCheckResourceAttr(policyRes, "pi_policy_authentication", "hmac-md5-96"),
+					resource.TestCheckResourceAttr(policyRes, "pi_policy_authentication", "hmac-sha-256-128"),
 				),
 			},
 		},
@@ -98,7 +98,7 @@ func testAccCheckIBMPIIPSecPolicyConfig(name string) string {
 		pi_policy_encryption = "3des-cbc"
 		pi_policy_key_lifetime = 180
 		pi_policy_pfs = true
-		pi_policy_authentication = "hmac-md5-96"
+		pi_policy_authentication = "hmac-sha-256-128"
 	}
 	`, acc.Pi_cloud_instance_id, name)
 }

--- a/ibm/service/power/resource_ibm_pi_vpn_connection_test.go
+++ b/ibm/service/power/resource_ibm_pi_vpn_connection_test.go
@@ -129,7 +129,7 @@ func testAccCheckIBMPIVPNConnectionConfig(name string) string {
 		pi_policy_encryption = "3des-cbc"
 		pi_policy_key_lifetime = 180
 		pi_policy_pfs = true
-		pi_policy_authentication = "hmac-md5-96"
+		pi_policy_authentication = "hmac-sha-256-128"
 	}
 	resource "ibm_pi_network" "private_network1" {
 		pi_cloud_instance_id	= "%[1]s"
@@ -168,7 +168,7 @@ func testAccCheckIBMPIVPNConnectionNetworkSubnetConfig(name string) string {
 		pi_policy_encryption = "3des-cbc"
 		pi_policy_key_lifetime = 180
 		pi_policy_pfs = true
-		pi_policy_authentication = "hmac-md5-96"
+		pi_policy_authentication = "hmac-sha-256-128"
 	}
 	resource "ibm_pi_network" "private_network1" {
 		pi_cloud_instance_id	= "%[1]s"

--- a/website/docs/r/pi_vpn_ipsec_policy.html.markdown
+++ b/website/docs/r/pi_vpn_ipsec_policy.html.markdown
@@ -21,7 +21,7 @@ The following example creates a IPSec Policy.
 		pi_policy_encryption = "3des-cbc"
 		pi_policy_key_lifetime = 180
 		pi_policy_pfs = true
-		pi_policy_authentication = "hmac-md5-96"
+		pi_policy_authentication = "hmac-sha-256-128"
 	}
 ```
 
@@ -51,7 +51,7 @@ ibm_pi_ipsec_policy provides the following [timeouts](https://www.terraform.io/d
 ## Argument reference 
 Review the argument references that you can specify for your resource. 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_policy_authentication`  - (Optional, String) Authentication for the IPSec Policy. Supported values are `none`(Default), `sha-256`, `sha-384`, and `sha1`.
+- `pi_policy_authentication`  - (Optional, String) Authentication for the IPSec Policy. Supported values are `none`(Default), `hmac-sha-256-128` and `hmac-sha1-96`.
 - `pi_policy_dh_group` - (Required, Integer) DH group of the IPSec Policy. Supported values are `1`,`2`,`5`,`14`,`19`,`20`,`24`.
 - `pi_policy_encryption`- (Required, String) Encryption of the IPSec Policy. Supported values are `3des-cbc`,`aes-128-cbc`,`aes-128-gcm`,`aes-192-cbc`,`aes-256-cbc`,`aes-256-gcm`,`des-cbc`.
 - `pi_policy_key_lifetime` - (Required, Integer) Policy key lifetime. Supported values:  `180` ≤ value ≤ `86400`.


### PR DESCRIPTION
 - IKEPolicy
   - Removed des-cbc encryption
   - Updated docs
 - IPSecPolicy
   - Removed des-cbc encryption
   - Removed sha-384, sha-256, and sha1 authentication. Added hmac-sha-256-128 and hmac-sha1-96
   - Updated tests
   - Updated docs

Signed off by: Chase Austin [chase@ibm.com](mailto:chase@ibm.com)
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
Output from acceptance testing:
```
=== RUN   TestAccIBMPIIKEPolicyBasic
--- PASS: TestAccIBMPIIKEPolicyBasic (50.71s)

=== RUN   TestAccIBMPIIPSecPolicyBasic
--- PASS: TestAccIBMPIIPSecPolicyBasic (30.80s)
```